### PR TITLE
Fix typo in docstring of filter_multi_output()

### DIFF
--- a/ffmpeg/_filters.py
+++ b/ffmpeg/_filters.py
@@ -14,12 +14,12 @@ def filter_multi_output(stream_spec, filter_name, *args, **kwargs):
 
     Example:
 
-        ```
+        ``
         split = ffmpeg.input('in.mp4').filter_multi_output('split')
         split0 = split.stream(0)
         split1 = split[1]
         ffmpeg.concat(split0, split1).output('out.mp4').run()
-        ```
+        ``
     """
     return FilterNode(stream_spec, filter_name, args=args, kwargs=kwargs, max_inputs=None)
 


### PR DESCRIPTION
Code example in docstring of filter_multi_output() is delimited by three backticks. Other code examples have only two backticks. In  the [formatted documentation for filter_multi_output()](https://kkroening.github.io/ffmpeg-python/index.html#ffmpeg.filter_multi_output), the example includes spurious backticks before and after. I think these spurious backticks in the output are the result of too many backticks in the docstring.